### PR TITLE
Improve ApplicationContext initialization to support scanning multiple package paths

### DIFF
--- a/spakky/bean/application_context.py
+++ b/spakky/bean/application_context.py
@@ -1,7 +1,7 @@
 from enum import Enum, auto
 from uuid import UUID, uuid4
 from types import ModuleType
-from typing import Any, Callable, Sequence, overload
+from typing import Any, Callable, Sequence, TypeAlias, overload
 
 from spakky.bean.bean import Bean, BeanFactoryType, UnknownType
 from spakky.bean.interfaces.bean_container import (
@@ -19,6 +19,8 @@ from spakky.bean.interfaces.bean_scanner import IBeanScanner
 from spakky.bean.primary import Primary
 from spakky.core.importing import list_classes, list_functions, list_modules
 from spakky.core.types import AnyT
+
+Module: TypeAlias = ModuleType | str
 
 
 class BeanType(Enum):
@@ -39,15 +41,20 @@ class ApplicationContext(
     __singleton_cache: dict[UUID, object]
     __post_processors: list[IBeanPostProcessor]
 
-    def __init__(self, package: ModuleType | str | None = None) -> None:
+    def __init__(self, package: Module | Sequence[Module] | None = None) -> None:
         self.__bean_map = {}
         self.__type_map = {}
         self.__bean_type_map = {}
         self.__bean_name_map = {}
         self.__singleton_cache = {}
         self.__post_processors = []
-        if package is not None:
-            self.scan(package)
+        if package is None:
+            return
+        if isinstance(package, Sequence):
+            for package_item in package:
+                self.scan(package_item)
+            return
+        self.scan(package)
 
     def __set_target_type(self, target_type: type) -> None:
         for base in target_type.__mro__:

--- a/tests/aop/conftest.py
+++ b/tests/aop/conftest.py
@@ -45,7 +45,7 @@ def get_application_context_fixture(
     def get_key() -> Key:
         return key
 
-    context: ApplicationContext = ApplicationContext(apps)
+    context: ApplicationContext = ApplicationContext([apps])
     context.register_bean_factory(get_logger)
     context.register_bean_factory(get_key)
     context.register_bean(DummyAdvisor)

--- a/tests/bean/test_application_context.py
+++ b/tests/bean/test_application_context.py
@@ -14,10 +14,13 @@ from spakky.bean.application_context import (
 from spakky.bean.bean import Bean
 from spakky.bean.primary import Primary
 from spakky.core.annotation import ClassAnnotation
-from tests import dummy_package
+from tests import dummy_package, second_dummy_package
 from tests.dummy_package.module_a import ComponentA, DummyA
 from tests.dummy_package.module_b import ComponentB, DummyB, UnmanagedB
 from tests.dummy_package.module_c import ComponentC, DummyC
+from tests.second_dummy_package.module_a import SecondComponentA, SecondDummyA
+from tests.second_dummy_package.module_b import SecondComponentB, SecondDummyB
+from tests.second_dummy_package.module_c import SecondComponentC, SecondDummyC
 
 
 def test_application_context_register_expect_success() -> None:
@@ -369,6 +372,29 @@ def test_application_context_initialize_with_pacakge() -> None:
     assert context.contains(required_type=DummyA) is False
     assert context.contains(required_type=DummyB) is False
     assert context.contains(required_type=DummyC) is False
+
+
+def test_application_context_initialize_with_multiple_pacakges() -> None:
+    context: ApplicationContext = ApplicationContext(
+        package=[
+            dummy_package,
+            second_dummy_package,
+        ]
+    )
+
+    assert context.contains(required_type=ComponentA) is True
+    assert context.contains(required_type=ComponentB) is True
+    assert context.contains(required_type=ComponentC) is True
+    assert context.contains(required_type=DummyA) is False
+    assert context.contains(required_type=DummyB) is False
+    assert context.contains(required_type=DummyC) is False
+
+    assert context.contains(required_type=SecondComponentA) is True
+    assert context.contains(required_type=SecondComponentB) is True
+    assert context.contains(required_type=SecondComponentC) is True
+    assert context.contains(required_type=SecondDummyA) is False
+    assert context.contains(required_type=SecondDummyB) is False
+    assert context.contains(required_type=SecondDummyC) is False
 
 
 def test_application_context_register_unmanaged_factory() -> None:

--- a/tests/second_dummy_package/module_a.py
+++ b/tests/second_dummy_package/module_a.py
@@ -1,0 +1,8 @@
+from spakky.bean.bean import Bean
+
+
+class SecondDummyA: ...
+
+
+@Bean()
+class SecondComponentA: ...

--- a/tests/second_dummy_package/module_b.py
+++ b/tests/second_dummy_package/module_b.py
@@ -1,0 +1,22 @@
+from spakky.bean.bean import Bean
+from spakky.core.annotation import ClassAnnotation
+
+
+@ClassAnnotation()
+class SecondDummyB: ...
+
+
+@Bean()
+class SecondComponentB: ...
+
+
+class SecondUnmanagedB: ...
+
+
+@Bean()
+def unmanaged_b() -> SecondUnmanagedB:
+    return SecondUnmanagedB()
+
+
+def hello_world() -> str:
+    return "Hello World"

--- a/tests/second_dummy_package/module_c.py
+++ b/tests/second_dummy_package/module_c.py
@@ -1,0 +1,8 @@
+from spakky.bean.bean import Bean
+
+
+class SecondDummyC: ...
+
+
+@Bean()
+class SecondComponentC: ...


### PR DESCRIPTION
The current implementation of ApplicationContext initialization only allows specifying a single package path. This pull request enhances the initialization process to support scanning multiple package paths, providing more flexibility in the component scan sequence.

Fixes #4